### PR TITLE
fixed bug in answerInlineQuery

### DIFF
--- a/lua-bot-api.lua
+++ b/lua-bot-api.lua
@@ -610,7 +610,7 @@ function answerInlineQuery(inline_query_id, results, cache_time, is_personal, ne
   local request_body = {}
 
   request_body.inline_query_id = inline_query_id
-  request_body.result = result
+  request_body.results = results
   request_body.cache_time = tonumber(cache_time)
   request_body.is_personal = tostring(is_personal)
   request_body.next_offset = next_offset


### PR DESCRIPTION
Wrong field name "result" was used in answer. Should be "results" according to
https://core.telegram.org/bots/api#answerinlinequery
