### PR TITLE
html error logging handled in folder

### DIFF
--- a/lua-bot-api.lua
+++ b/lua-bot-api.lua
@@ -40,7 +40,13 @@ function JSON:onDecodeError(message, text, location, etc)
       message = string.format("%s: %s", message, text)
     end
   end
-  print((os.date("%x %X")), "Error while decoding JSON:\n", message)
+  --print((os.date("%x %X")), "Error while decoding JSON:\n", message)
+  local datefile = os.date("%d-%m-%Y.txt")
+  print((os.date("%x %X")), "Error: decode JSON, logged in ".. datefile)
+  local log = io.open("errors/" .. datefile,"a+") -- open log
+  log:write((os.date("%x %X")), "Error while decoding JSON:\n", message .. "\n") -- write in log
+  log:close()
+          
 end
 
 function JSON:onDecodeOfHTMLError(message, text, _nil, etc)
@@ -51,7 +57,12 @@ function JSON:onDecodeOfHTMLError(message, text, _nil, etc)
       message = string.format("%s: %s", message, text)
     end
   end
-  print((os.date("%x %X")), "Error while decoding JSON [HTML]:\n", message)
+  --print((os.date("%x %X")), "Error while decoding JSON [HTML]:\n", message)
+  local datefile = os.date("%d-%m-%Y.txt")
+  print((os.date("%x %X")), "Error: decode JSON [HTML], logged in ".. datefile)
+  local log = io.open("errors/" .. datefile,"a+") -- open log
+  log:write((os.date("%x %X")), "Error while decoding JSON [HTML]:\n", message .. "\n") -- write in log
+  log:close()
 end
 
 function JSON:onDecodeOfNilError(message, _nil, _nil, etc)


### PR DESCRIPTION
Added a way to log the html decode error messages into a folder called "errors".
Creates files like "DD-MM-YYYY.txt".
